### PR TITLE
Set default un argument parameter

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -10,9 +10,12 @@ require(timecard)
 cat("Push Enter key till a cursor advents...")
 }
 
-.onLoad <- function(libname = find.package("timecard"), pkgname = "timecard"){
-  if (!interactive()) return()
-  un <-   readline("username: ")
+.onLoad <- function(libname = find.package("timecard"), pkgname = "timecard", un = getOption("github.user")){
+  if (!interactive())
+    return()
+  if (is.null(un)) {
+    un <-   readline("username: ")
+  }
   write(un, "timecard_temporary")
   sushi(1)
   res <- httr::POST("https://docs.google.com/forms/d/1PUoc23ss4hZ32uRHAczPkZgQkKgiZPxujL-f-PFfwkw/formResponse",


### PR DESCRIPTION
timecardを読み込んだ際、devtoolsパッケージの設定として.Rprofileに`options(github.user = "username")`がある場合、自動的に引数のunにusernameが渡されるようにしました
